### PR TITLE
Fix CSS selectors for product card selection, removing reliance on dy…

### DIFF
--- a/zakilo_chrome/content/auchan.js
+++ b/zakilo_chrome/content/auchan.js
@@ -1,8 +1,8 @@
 class AuchanProductCard {
     // селекторы и константы для «Ашан»
-    static CARD_SELECTOR     = 'div.styles_productCard__Qy_9h.styles_catalogListPage_item__NAAw9';
-    static PRICE_SEL         = '.styles_productCardContentPanel_price__MqlWB';
-    static NAME_SEL          = '.styles_productCardContentPanel_name__072Y7';
+    static CARD_SELECTOR     = 'div[class*=styles_productCard][class*=styles_catalogListPage_item]';
+    static PRICE_SEL         = '[class*=styles_productCardContentPanel_price]';
+    static NAME_SEL          = '[class*=styles_productCardContentPanel_name]';
     static UNIT_PRICE_SEL    = '[data-testid="unit-price"]';
 
     static mutationObserver  = null;

--- a/zakilo_chrome/content/kuper.js
+++ b/zakilo_chrome/content/kuper.js
@@ -1,10 +1,10 @@
 class CooperProductCard {
     // Универсальный селектор для всех карточек продукта
-    static CARD_SELECTOR     = 'div.ProductCard_root__zO_B9';
+    static CARD_SELECTOR     = 'div[class*=ProductCard_root]';
     // Акционная или обычная цена внутри блока цены
-    static PRICE_NEW_SEL     = '.ProductCard_price__LnWjd .ProductCardPrice_accent__6BZDJ.CommonProductCard_priceText__S5e9l, .ProductCard_price__LnWjd .ProductCardPrice_price__zSwp0.CommonProductCard_priceText__S5e9l';
+    static PRICE_NEW_SEL     = '[class*=ProductCard_price] [class*=ProductCardPrice_accent][class*=CommonProductCard_priceText], [class*=ProductCard_price] [class*=ProductCardPrice_price][class*=CommonProductCard_priceText]';
     // Вес или уже готовая unit-цена
-    static VOLUME_SEL        = 'div.ProductCard_volume__RHLb0';
+    static VOLUME_SEL        = 'div[class*=ProductCard_volume]';
     // Наблюдаем за всем телом документа, чтобы ловить любые динамические вставки
     static OBSERVE_CONTAINER = 'body';
     // Метка unit-price
@@ -97,7 +97,7 @@ class CooperProductCard {
                 fontSize: '18px'
             });
 
-            const priceContainer = priceEl.closest('.ProductCard_price__LnWjd.CommonProductCard_price__XM9uA');
+            const priceContainer = priceEl.closest('[class*=ProductCard_price][class*=CommonProductCard_price]');
             if (!priceContainer) throw new Error('Контейнер цены не найден');
             priceContainer.querySelectorAll(CooperProductCard.UNIT_PRICE_SEL).forEach(e => e.remove());
             priceContainer.appendChild(span);
@@ -106,7 +106,7 @@ class CooperProductCard {
         // --- /Специальный кейс ---
 
         // Обычный расчёт по весу или объёму
-        const priceContainer = priceEl.closest('.ProductCard_price__LnWjd.CommonProductCard_price__XM9uA');
+        const priceContainer = priceEl.closest('[class*=ProductCard_price][class*=CommonProductCard_price]');
         if (!priceContainer) throw new Error('Контейнер цены не найден');
 
         // Получаем числовую цену из priceEl

--- a/zakilo_chrome/content/pyaterochka.js
+++ b/zakilo_chrome/content/pyaterochka.js
@@ -5,13 +5,13 @@ class ProductCard {
     constructor(cardEl) {
         this.cardEl = cardEl;
         this.logPrefix = '[pyaterochka]:';
-        this.priceSel = '.priceContainer_priceContainerCatalog__LIxni';
-        this.weightSel = '.mainInformation_weight__o6cXn';
+        this.priceSel = '[class*=priceContainer_priceContainerCatalog]';
+        this.weightSel = '[class*=mainInformation_weight]';
     }
 
     static runAll() {
         const cards = document.querySelectorAll(
-            '[data-qa^="product-card-"], .productFilterGrid_cardContainer__oyUJZ'
+            '[data-qa^="product-card-"], [class*=productFilterGrid_cardContainer]'
         );
         console.log('economist:', 'стартовая инициализация, найдено карточек:', cards.length);
         cards.forEach(el => ProductCard._tryProcess(el));
@@ -30,7 +30,7 @@ class ProductCard {
     }
 
     static watchMutations() {
-        const container = document.querySelector('.chakra-stack.catalogPage_container__zsZjW');
+        const container = document.querySelector('[class*=chakra-stack.catalogPage_container]');
         if (!container) {
             console.error('economist:', 'контейнер каталога не найден для наблюдения');
             return;
@@ -39,11 +39,11 @@ class ProductCard {
             muts.forEach(m => {
                 m.addedNodes.forEach(n => {
                     if (!(n instanceof HTMLElement)) return;
-                    if (n.matches('[data-qa^="product-card-"], .productFilterGrid_cardContainer__oyUJZ')) {
+                    if (n.matches('[data-qa^="product-card-"], [class*=productFilterGrid_cardContainer]')) {
                         console.log('economist:', 'обнаружена новая карточка');
                         ProductCard._tryProcess(n);
                     }
-                    n.querySelectorAll?.('[data-qa^="product-card-"], .productFilterGrid_cardContainer__oyUJZ')
+                    n.querySelectorAll?.('[data-qa^="product-card-"], [class*=productFilterGrid_cardContainer]')
                         .forEach(el => {
                             console.log('economist:', 'обнаружена вложенная карточка');
                             ProductCard._tryProcess(el);
@@ -95,7 +95,7 @@ class ProductCard {
         const containers = this.cardEl.querySelectorAll(this.priceSel);
         containers.forEach(pc => {
             pc.querySelectorAll('p').forEach(p => {
-                if (p.classList.contains('priceContainer_cent__KeKyD')) {
+                if ([...p.classList].some(cls => cls.startsWith('priceContainer_cent'))) {
                     p.style.fontSize = '0.7em';
                 } else {
                     p.style.fontSize = '0.96em';
@@ -139,8 +139,8 @@ class ProductCard {
     _getEffectivePrice() {
         const pc = this.cardEl.querySelector(this.priceSel);
         if (!pc) throw new Error('price container не найден');
-        const disc = pc.querySelector('.priceContainer_discountInternalContainer__MhRsi');
-        const block = disc || pc.querySelector('.priceContainer_totalContainer__rvZ0b');
+        const disc = pc.querySelector('[class*=priceContainer_discountInternalContainer]');
+        const block = disc || pc.querySelector('[class*=priceContainer_totalContainer]');
         if (!block) throw new Error('блок с цифрами цены не найден');
         const ps = block.querySelectorAll('p');
         const whole = parseInt(ps[0]?.textContent, 10);

--- a/zakilo_chrome/content/samokat.js
+++ b/zakilo_chrome/content/samokat.js
@@ -1,12 +1,12 @@
 class SamokatProductCard {
-    static CARD_SELECTOR      = '.ProductCard_root__OCLMl';
+    static CARD_SELECTOR      = '[class*=ProductCard_root]';
     // Выбираем либо акционную цену (последний span), либо обычную
-    static PRICE_NEW_SEL      = '.ProductCardActions_text__3Uohy span span:last-child';
-    static WEIGHT_SEL         = '.ProductCard_specification__Y0xA6 span:first-child';
+    static PRICE_NEW_SEL      = '[class*=ProductCardActions_text] span span:last-child';
+    static WEIGHT_SEL         = '[class*=ProductCard_specification] span:first-child';
     static UNIT_PRICE_SEL     = '[data-testid="unit-price"]';
     static OBSERVE_CONTAINER  = '.swiper-wrapper';
     // Контейнер для вставки цены за единицу
-    static DETAILS_SEL        = '.ProductCard_details__S6PcT';
+    static DETAILS_SEL        = '[class*=ProductCard_details]';
 
     static init() {
         SamokatProductCard.log('=== ИНИЦИАЛИЗАЦИЯ SamokatProductCard ===');

--- a/zakilo_firefox/content/auchan.js
+++ b/zakilo_firefox/content/auchan.js
@@ -1,8 +1,8 @@
 class AuchanProductCard {
     // селекторы и константы для «Ашан»
-    static CARD_SELECTOR     = 'div.styles_productCard__Qy_9h.styles_catalogListPage_item__NAAw9';
-    static PRICE_SEL         = '.styles_productCardContentPanel_price__MqlWB';
-    static NAME_SEL          = '.styles_productCardContentPanel_name__072Y7';
+    static CARD_SELECTOR     = 'div[class*=styles_productCard][class*=styles_catalogListPage_item]';
+    static PRICE_SEL         = '[class*=styles_productCardContentPanel_price]';
+    static NAME_SEL          = '[class*=styles_productCardContentPanel_name]';
     static UNIT_PRICE_SEL    = '[data-testid="unit-price"]';
 
     static mutationObserver  = null;

--- a/zakilo_firefox/content/kuper.js
+++ b/zakilo_firefox/content/kuper.js
@@ -1,10 +1,10 @@
 class CooperProductCard {
     // Универсальный селектор для всех карточек продукта
-    static CARD_SELECTOR     = 'div.ProductCard_root__zO_B9';
+    static CARD_SELECTOR     = 'div[class*=ProductCard_root]';
     // Акционная или обычная цена внутри блока цены
-    static PRICE_NEW_SEL     = '.ProductCard_price__LnWjd .ProductCardPrice_accent__6BZDJ.CommonProductCard_priceText__S5e9l, .ProductCard_price__LnWjd .ProductCardPrice_price__zSwp0.CommonProductCard_priceText__S5e9l';
+    static PRICE_NEW_SEL     = '[class*=ProductCard_price] [class*=ProductCardPrice_accent][class*=CommonProductCard_priceText], [class*=ProductCard_price] [class*=ProductCardPrice_price][class*=CommonProductCard_priceText]';
     // Вес или уже готовая unit-цена
-    static VOLUME_SEL        = 'div.ProductCard_volume__RHLb0';
+    static VOLUME_SEL        = 'div[class*=ProductCard_volume]';
     // Наблюдаем за всем телом документа, чтобы ловить любые динамические вставки
     static OBSERVE_CONTAINER = 'body';
     // Метка unit-price
@@ -97,7 +97,7 @@ class CooperProductCard {
                 fontSize: '18px'
             });
 
-            const priceContainer = priceEl.closest('.ProductCard_price__LnWjd.CommonProductCard_price__XM9uA');
+            const priceContainer = priceEl.closest('[class*=ProductCard_price][class*=CommonProductCard_price]');
             if (!priceContainer) throw new Error('Контейнер цены не найден');
             priceContainer.querySelectorAll(CooperProductCard.UNIT_PRICE_SEL).forEach(e => e.remove());
             priceContainer.appendChild(span);
@@ -106,7 +106,7 @@ class CooperProductCard {
         // --- /Специальный кейс ---
 
         // Обычный расчёт по весу или объёму
-        const priceContainer = priceEl.closest('.ProductCard_price__LnWjd.CommonProductCard_price__XM9uA');
+        const priceContainer = priceEl.closest('[class*=ProductCard_price][class*=CommonProductCard_price]');
         if (!priceContainer) throw new Error('Контейнер цены не найден');
 
         // Получаем числовую цену из priceEl

--- a/zakilo_firefox/content/pyaterochka.js
+++ b/zakilo_firefox/content/pyaterochka.js
@@ -5,13 +5,13 @@ class ProductCard {
     constructor(cardEl) {
         this.cardEl = cardEl;
         this.logPrefix = '[pyaterochka]:';
-        this.priceSel = '.priceContainer_priceContainerCatalog__LIxni';
-        this.weightSel = '.mainInformation_weight__o6cXn';
+        this.priceSel = '[class*=priceContainer_priceContainerCatalog]';
+        this.weightSel = '[class*=mainInformation_weight]';
     }
 
     static runAll() {
         const cards = document.querySelectorAll(
-            '[data-qa^="product-card-"], .productFilterGrid_cardContainer__oyUJZ'
+            '[data-qa^="product-card-"], [class*=productFilterGrid_cardContainer]'
         );
         console.log('economist:', 'стартовая инициализация, найдено карточек:', cards.length);
         cards.forEach(el => ProductCard._tryProcess(el));
@@ -30,7 +30,7 @@ class ProductCard {
     }
 
     static watchMutations() {
-        const container = document.querySelector('.chakra-stack.catalogPage_container__zsZjW');
+        const container = document.querySelector('[class*=chakra-stack.catalogPage_container]');
         if (!container) {
             console.error('economist:', 'контейнер каталога не найден для наблюдения');
             return;
@@ -39,11 +39,11 @@ class ProductCard {
             muts.forEach(m => {
                 m.addedNodes.forEach(n => {
                     if (!(n instanceof HTMLElement)) return;
-                    if (n.matches('[data-qa^="product-card-"], .productFilterGrid_cardContainer__oyUJZ')) {
+                    if (n.matches('[data-qa^="product-card-"], [class*=productFilterGrid_cardContainer]')) {
                         console.log('economist:', 'обнаружена новая карточка');
                         ProductCard._tryProcess(n);
                     }
-                    n.querySelectorAll?.('[data-qa^="product-card-"], .productFilterGrid_cardContainer__oyUJZ')
+                    n.querySelectorAll?.('[data-qa^="product-card-"], [class*=productFilterGrid_cardContainer]')
                         .forEach(el => {
                             console.log('economist:', 'обнаружена вложенная карточка');
                             ProductCard._tryProcess(el);
@@ -95,7 +95,7 @@ class ProductCard {
         const containers = this.cardEl.querySelectorAll(this.priceSel);
         containers.forEach(pc => {
             pc.querySelectorAll('p').forEach(p => {
-                if (p.classList.contains('priceContainer_cent__KeKyD')) {
+                if ([...p.classList].some(cls => cls.includes('priceContainer_cent'))) {
                     p.style.fontSize = '0.7em';
                 } else {
                     p.style.fontSize = '0.96em';
@@ -139,8 +139,8 @@ class ProductCard {
     _getEffectivePrice() {
         const pc = this.cardEl.querySelector(this.priceSel);
         if (!pc) throw new Error('price container не найден');
-        const disc = pc.querySelector('.priceContainer_discountInternalContainer__MhRsi');
-        const block = disc || pc.querySelector('.priceContainer_totalContainer__rvZ0b');
+        const disc = pc.querySelector('[class*=priceContainer_discountInternalContainer]');
+        const block = disc || pc.querySelector('[class*=priceContainer_totalContainer]');
         if (!block) throw new Error('блок с цифрами цены не найден');
         const ps = block.querySelectorAll('p');
         const whole = parseInt(ps[0]?.textContent, 10);

--- a/zakilo_firefox/content/samokat.js
+++ b/zakilo_firefox/content/samokat.js
@@ -1,12 +1,12 @@
 class SamokatProductCard {
-    static CARD_SELECTOR      = '.ProductCard_root__OCLMl';
+    static CARD_SELECTOR      = '[class*=ProductCard_root]';
     // Выбираем либо акционную цену (последний span), либо обычную
-    static PRICE_NEW_SEL      = '.ProductCardActions_text__3Uohy span span:last-child';
-    static WEIGHT_SEL         = '.ProductCard_specification__Y0xA6 span:first-child';
+    static PRICE_NEW_SEL      = '[class*=ProductCardActions_text] span span:last-child';
+    static WEIGHT_SEL         = '[class*=ProductCard_specification] span:first-child';
     static UNIT_PRICE_SEL     = '[data-testid="unit-price"]';
     static OBSERVE_CONTAINER  = '.swiper-wrapper';
     // Контейнер для вставки цены за единицу
-    static DETAILS_SEL        = '.ProductCard_details__S6PcT';
+    static DETAILS_SEL        = '[class*=ProductCard_details]';
 
     static init() {
         SamokatProductCard.log('=== ИНИЦИАЛИЗАЦИЯ SamokatProductCard ===');


### PR DESCRIPTION
Заменил селекторы на `[class*="..."]`, чтобы искать элементы по основной части имени класса без учёта сгенерированной части. Теперь селектор ищет совпадение в любой части атрибута `class`, на случай если в начале окажется другой класс.