### PR TITLE
Привёл package-lock в соответствие с package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "convert-units": "2.3.4"
       },
       "devDependencies": {
-        "@rollup/rollup-win32-x64-msvc": "4.44.0",
         "@testing-library/dom": "^9.3.4",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^14.2.1",
@@ -39,6 +38,9 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-win32-x64-msvc": "4.44.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1291,7 +1293,7 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "optional": true,
       "os": [
         "win32"
       ]


### PR DESCRIPTION
`@rollup/rollup-win32-x64-msvc` в package.json лежит в `optionalDependencies`, а в package-lock остался помечен как `dev`. Из-за этого после `npm install` lock каждый раз переписывается и в рабочем дереве висит лишний diff. Перегенерировал lock — теперь сходится. На установку и сборку не влияет: пакет Windows-only и на других платформах всё равно пропускается.