### PR TITLE
Ozon: учитывать мультипак "вес × N шт" при расчёте цены за кг/л

### DIFF
--- a/src/strategies/OzonStrategy.ts
+++ b/src/strategies/OzonStrategy.ts
@@ -32,7 +32,17 @@ export class OzonStrategy extends ParserStrategy {
 
     const value = parseFloat(match[1].replace(",", "."));
     const unit = match[2].toLowerCase();
-    return getConvertedUnit(value, unit);
+
+    // Название — свободный текст продавца, формат непредсказуем. Поэтому учитываем
+    // мультипак только по однозначному сигналу: множитель ("х"/"x"/"×"/"*") + число + "шт",
+    // напр. "800 гр. х 6 шт." → вес одной упаковки умножаем на количество.
+    // Глиф обязателен: он отделяет настоящий мультипак ("800 г х 6 шт") от случая, когда
+    // итог уже указан, а разбивка в скобках ("4,8 кг (6 шт. по 800 г)") — там умножать нельзя.
+    // Штучные товары (unit === "шт") не трогаем: там количество и так в цене за штуку.
+    const packMatch = unit !== "шт" ? nameText.match(/[xXхХ×*]\s*(\d+)\s*шт/) : null;
+    const count = packMatch ? parseInt(packMatch[1], 10) : 1;
+
+    return getConvertedUnit(value * count, unit);
   }
 
   renderUnitPrice(cardEl: HTMLElement, unitPrice: number, unitLabel: string): void {

--- a/src/strategies/__test_data__/ozon/card4.json
+++ b/src/strategies/__test_data__/ozon/card4.json
@@ -3,10 +3,10 @@
   "expectedParsedPrice": 1222,
   "expectedParsedQuantity": {
     "unitLabel": "1 л",
-    "multiplier": 1.053
+    "multiplier": 0.0877
   },
   "expectedUnitPrice": {
-    "price": 1287,
+    "price": 107,
     "label": "1 л",
     "styles": {
       "display": "inline-block",

--- a/src/strategies/__test_data__/ozon/card_multipack.json
+++ b/src/strategies/__test_data__/ozon/card_multipack.json
@@ -1,0 +1,22 @@
+{
+  "html": "<div class=\"tile-root\"><div class=\"price-wrap\"><span class=\"tsHeadline500Medium\">391 ₽</span></div><div class=\"name-wrap\"><span class=\"tsBody500Medium\">Гречневая крупа Миллант 800 гр. х 6 шт.</span></div></div>",
+  "expectedParsedPrice": 391,
+  "expectedParsedQuantity": {
+    "unitLabel": "1 кг",
+    "multiplier": 0.20833
+  },
+  "expectedUnitPrice": {
+    "price": 81,
+    "label": "1 кг",
+    "styles": {
+      "display": "inline-block",
+      "marginLeft": "0.5em",
+      "color": "rgb(0, 0, 0)",
+      "background": "var(--accent-color, #00C66A20) var(--accent-color, #00C66A20)",
+      "padding": "2px 6px",
+      "borderRadius": "4px",
+      "fontWeight": "900",
+      "fontSize": "calc(0.95vw)"
+    }
+  }
+}

--- a/src/strategies/__test_data__/ozon/card_total_in_pack.json
+++ b/src/strategies/__test_data__/ozon/card_total_in_pack.json
@@ -1,0 +1,22 @@
+{
+  "html": "<div class=\"tile-root\"><div class=\"price-wrap\"><span class=\"tsHeadline500Medium\">508 ₽</span></div><div class=\"name-wrap\"><span class=\"tsBody500Medium\">Гречневая экстра Алтайская мягкая упаковка 4,8 кг (6 шт. по 800 г.)</span></div></div>",
+  "expectedParsedPrice": 508,
+  "expectedParsedQuantity": {
+    "unitLabel": "1 кг",
+    "multiplier": 0.20833
+  },
+  "expectedUnitPrice": {
+    "price": 106,
+    "label": "1 кг",
+    "styles": {
+      "display": "inline-block",
+      "marginLeft": "0.5em",
+      "color": "rgb(0, 0, 0)",
+      "background": "var(--accent-color, #00C66A20) var(--accent-color, #00C66A20)",
+      "padding": "2px 6px",
+      "borderRadius": "4px",
+      "fontWeight": "900",
+      "fontSize": "calc(0.95vw)"
+    }
+  }
+}


### PR DESCRIPTION
Closes #44

На Ozon в названии (свободный текст продавца) часто пишут "вес × кол-во шт", напр. "800 гр. х 6 шт.". Раньше брали вес одной пачки -> цена за кг/л завышалась кратно.

Теперь при явном множителе (х/x/×/*) + число + "шт" вес умножается на количество:
- Миллант 800 гр х 6 шт, 391 ₽: 489 ₽/кг -> 81 (4.8 кг)
- Молоко 950 мл х 12 шт, 1222 ₽: 1287 ₽/л -> 107 (11.4 л)

Множитель обязателен -- он отделяет настоящий мультипак от случая, когда итог уже указан, а разбивка дана в скобках ("4,8 кг (6 шт по 800 г)"), где умножать нельзя.

Тесты: card4 держал старое битое ожидание -- поправлен. Добавлены два кейса: мультипак с множителем (умножаем) и итог в скобках (не умножаем).

Не входит (отдельные ишью): #45 (мультипак без знака умножения), #46 (количество перед весом).