### PR TITLE
ozon: Цена за метр и за гигабайт

### DIFF
--- a/src/strategies/OzonStrategy.ts
+++ b/src/strategies/OzonStrategy.ts
@@ -25,7 +25,15 @@ export class OzonStrategy extends ParserStrategy {
 
   parseQuantity(cardEl: HTMLElement): UnitLabel | NoneUnitLabel {
     const nameText = cardEl.querySelector(this.selectors.name)?.textContent?.trim() ?? "";
-    const regex = /([\d.,]+)\s*(г|гр|кг|мл|л|шт)/i;
+    // Единицы трёх типов, чтобы не путать с «соседними» обозначениями в названии:
+    //  • объём данных (накопители): тб/гб/мб + латиница; (?!ит) отсекает скорость
+    //    интерфейса «6 Гбит/с», иначе ёмкость спуталась бы с гигабитами;
+    //  • метраж (трубы, кабель): длина в метрах, диаметр и стенка — в мм, поэтому
+    //    м(?![мб]) отсекает «мм» и «Мбит»;
+    //  • вес/объём: граммы г(?!б), чтобы одиночное «г» не цеплялось за «Гбит/ГБ».
+    // Цифровые единицы стоят раньше г/м: при разборе важен порядок альтернатив.
+    const regex =
+      /([\d.,]+)\s*(тб|tb|гб(?!ит)|gb|мб(?!ит)|mb|кг|гр|г(?!б)|мл|л|шт|метров|метра|метр|м(?![мб]))/i;
     const match = nameText.match(regex);
 
     if (!match) return { unitLabel: null, multiplier: null } as NoneUnitLabel;

--- a/src/utils/converters.test.ts
+++ b/src/utils/converters.test.ts
@@ -123,6 +123,16 @@ describe("converters", () => {
 
         // Price per 100g
         [100, "г", { unitLabel: "1 кг", multiplier: 10, [Symbol.for("tag")]: { UnitLabel: true } } as UnitLabel],
+
+        // Length (метраж труб, кабеля)
+        [50, "м", { unitLabel: "1 м", multiplier: 0.02, [Symbol.for("tag")]: { UnitLabel: true } } as UnitLabel],
+        [1, "метр", { unitLabel: "1 м", multiplier: 1, [Symbol.for("tag")]: { UnitLabel: true } } as UnitLabel],
+        [25, "метров", { unitLabel: "1 м", multiplier: 0.04, [Symbol.for("tag")]: { UnitLabel: true } } as UnitLabel],
+
+        // Digital (ёмкость накопителей, нормализация к ГБ; ТБ и МБ по основанию 1024)
+        [500, "гб", { unitLabel: "1 ГБ", multiplier: 0.002, [Symbol.for("tag")]: { UnitLabel: true } } as UnitLabel],
+        [2, "тб", { unitLabel: "1 ГБ", multiplier: 1 / 2048, [Symbol.for("tag")]: { UnitLabel: true } } as UnitLabel],
+        [512, "мб", { unitLabel: "1 ГБ", multiplier: 2, [Symbol.for("tag")]: { UnitLabel: true } } as UnitLabel],
       ])("should convert %i %s to standard unit", (value, unit, expected) => {
         expect(getConvertedUnit(value, unit)).toEqual(expected);
       });

--- a/src/utils/converters.ts
+++ b/src/utils/converters.ts
@@ -6,8 +6,8 @@ import convert from "convert-units";
 // Types
 type RussianUnit = keyof typeof rusToConvertUnit;
 type ConvertUnit = (typeof rusToConvertUnit)[RussianUnit];
-type TargetUnit = Extract<ConvertUnit, "kg" | "l" | "ea">;
-type ConverssionsMeasures = Extract<Measure, "mass" | "volume"> | "ea";
+type TargetUnit = Extract<ConvertUnit, "kg" | "l" | "ea" | "m" | "GB">;
+type ConverssionsMeasures = Extract<Measure, "mass" | "volume" | "length" | "digital"> | "ea";
 type MeasurableUnit = Exclude<ConvertUnit, "ea">;
 
 // Error messages
@@ -28,17 +28,32 @@ const rusToConvertUnit = {
   л: "l",
   шт: "ea",
   "шт.": "ea",
+  м: "m",
+  метр: "m",
+  метра: "m",
+  метров: "m",
+  // Объём данных (накопители): кириллица и латиница; нормализуем к гигабайтам.
+  тб: "TB",
+  tb: "TB",
+  гб: "GB",
+  gb: "GB",
+  мб: "MB",
+  mb: "MB",
 } as const;
 
 const measureToTargetUnit: Record<ConverssionsMeasures, ConvertUnit> = {
   mass: "kg",
   volume: "l",
+  length: "m",
+  digital: "GB",
   ea: "ea",
 } as const;
 
 const targetUnitLabels: Record<TargetUnit, string> = {
   kg: "1 кг",
   l: "1 л",
+  m: "1 м",
+  GB: "1 ГБ",
   ea: "1 шт",
 } as const;
 


### PR DESCRIPTION
Сейчас на Озоне для труб ПНД и для жёстких дисков цена за единицу не показывается, потому что разбор названия знает только вес, объём и штуки.

Эта правка учит его метрам для труб и кабеля, и гигабайтам с терабайтами и мегабайтами для накопителей. Длина не цепляется за диаметр в мм, а ёмкость за скорость интерфейса в Гбит.

Проверено на живой выдаче. Для труб метраж распознаётся везде, где он указан в названии. Для дисков цена за гигабайт считается корректно, скорость SATA 6 Гбит не мешает.

Меняется только разбор единиц, к весу, объёму и штукам ничего не трогается. Тесты на новые единицы добавлены.
